### PR TITLE
fix(firewall): fix fw config for 1.4-rolling-202312120306

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -78,7 +78,7 @@ git branch --set-upstream-to=origin/"$repoBranch" "$repoBranch" -q
 
 echo "Loading secrets into ENV vars..."
 if [ -f "/config/secrets.sops.env" ]; then
-  export SOPS_AGE_KEY_FILE=/config/secrets/age.key
+  export SOPS_AGE_KEY_FILE=/config/secrets/keys.txt
 
   mapfile environmentAsArray < <(
     sops --decrypt "/config/secrets.sops.env" |

--- a/config-parts/fw-00-mgmt.sh
+++ b/config-parts/fw-00-mgmt.sh
@@ -9,8 +9,8 @@ set firewall ipv4 name mgmt-infra description 'From mgmt to infra'
 ### --- 999-infra : Drop Invalid Packets
 set firewall ipv4 name mgmt-infra rule 999 action 'drop'
 set firewall ipv4 name mgmt-infra rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name mgmt-infra rule 999 log 'enable'
-set firewall ipv4 name mgmt-infra rule 999 state invalid 'enable'
+set firewall ipv4 name mgmt-infra rule 999 log
+set firewall ipv4 name mgmt-infra rule 999 state invalid 
 
 # (20) From mgmt to home
 set firewall ipv4 name mgmt-home default-action 'accept'
@@ -18,8 +18,8 @@ set firewall ipv4 name mgmt-home description 'From mgmt to home'
 ### --- 999-home : Drop Invalid Packets
 set firewall ipv4 name mgmt-home rule 999 action 'drop'
 set firewall ipv4 name mgmt-home rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name mgmt-home rule 999 log 'enable'
-set firewall ipv4 name mgmt-home rule 999 state invalid 'enable'
+set firewall ipv4 name mgmt-home rule 999 log
+set firewall ipv4 name mgmt-home rule 999 state invalid 
 
 # (30) From mgmt to iot
 set firewall ipv4 name mgmt-iot default-action 'accept'
@@ -27,8 +27,8 @@ set firewall ipv4 name mgmt-iot description 'From mgmt to iot'
 ### --- 999-iot : Drop Invalid Packets
 set firewall ipv4 name mgmt-iot rule 999 action 'drop'
 set firewall ipv4 name mgmt-iot rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name mgmt-iot rule 999 log 'enable'
-set firewall ipv4 name mgmt-iot rule 999 state invalid 'enable'
+set firewall ipv4 name mgmt-iot rule 999 log
+set firewall ipv4 name mgmt-iot rule 999 state invalid 
 
 # (40) From mgmt to cctv
 set firewall ipv4 name mgmt-cctv default-action 'accept'
@@ -36,8 +36,8 @@ set firewall ipv4 name mgmt-cctv description 'From mgmt to cctv'
 ### --- 999-cctv : Drop Invalid Packets
 set firewall ipv4 name mgmt-cctv rule 999 action 'drop'
 set firewall ipv4 name mgmt-cctv rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name mgmt-cctv rule 999 log 'enable'
-set firewall ipv4 name mgmt-cctv rule 999 state invalid 'enable'
+set firewall ipv4 name mgmt-cctv rule 999 log
+set firewall ipv4 name mgmt-cctv rule 999 state invalid
 
 # (97) From mgmt to containers
 set firewall ipv4 name mgmt-containers default-action 'accept'
@@ -45,8 +45,8 @@ set firewall ipv4 name mgmt-containers description 'From mgmt to containers'
 ### --- 999-containers : Drop Invalid Packets
 set firewall ipv4 name mgmt-containers rule 999 action 'drop'
 set firewall ipv4 name mgmt-containers rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name mgmt-containers rule 999 log 'enable'
-set firewall ipv4 name mgmt-containers rule 999 state invalid 'enable'
+set firewall ipv4 name mgmt-containers rule 999 log
+set firewall ipv4 name mgmt-containers rule 999 state invalid
 
 # (98) From mgmt to local
 set firewall ipv4 name mgmt-local default-action 'accept'
@@ -54,8 +54,8 @@ set firewall ipv4 name mgmt-local description 'From mgmt to local'
 ### --- 999-local : Drop Invalid Packets
 set firewall ipv4 name mgmt-local rule 999 action 'drop'
 set firewall ipv4 name mgmt-local rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name mgmt-local rule 999 log 'enable'
-set firewall ipv4 name mgmt-local rule 999 state invalid 'enable'
+set firewall ipv4 name mgmt-local rule 999 log
+set firewall ipv4 name mgmt-local rule 999 state invalid
 
 # (99) From mgmt to wan
 set firewall ipv4 name mgmt-wan default-action 'accept'

--- a/config-parts/fw-10-infra.sh
+++ b/config-parts/fw-10-infra.sh
@@ -4,33 +4,28 @@
 
 #### infra ----------------------------------------------------------------------------
 # (00) From infra to management
-set firewall ipv4 name infra-management default-action 'accept'
-set firewall ipv4 name infra-management description 'From infra to management'
+set firewall ipv4 name infra-mgmt default-action 'accept'
+set firewall ipv4 name infra-mgmt description 'From infra to management'
 ### --- 999-management : Drop Invalid Packets
-set firewall ipv4 name infra-management rule 999 action 'drop'
-set firewall ipv4 name infra-management rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name infra-management rule 999 log 'enable'
-set firewall ipv4 name infra-management rule 999 state invalid 'enable'
+set firewall ipv4 name infra-mgmt rule 999 action 'drop'
+set firewall ipv4 name infra-mgmt rule 999 description 'Rule: Drop_Invalid'
+set firewall ipv4 name infra-mgmt rule 999 log
+set firewall ipv4 name infra-mgmt rule 999 state invalid
 
 # (20) From infra to home
 set firewall ipv4 name infra-home default-action 'drop'
 set firewall ipv4 name infra-home description 'From infra to home'
 set firewall ipv4 name infra-home enable-default-log
-### --- 010-home : Accept HTTP Traffic (80)
+### --- 010-home : Accept HTTP/HTTPS Traffic (80,443)
 set firewall ipv4 name infra-home rule 10 action 'accept'
-set firewall ipv4 name infra-home rule 10 description 'Rule: Accept_HTTP'
-set firewall ipv4 name infra-home rule 10 destination port '80'
+set firewall ipv4 name infra-home rule 10 description 'Rule: Accept_HTTP_HTTPS'
+set firewall ipv4 name infra-home rule 10 destination port 'http,https'
 set firewall ipv4 name infra-home rule 10 protocol 'tcp'
-### --- 020-home : Accept HTTPS Traffic (443)
-set firewall ipv4 name infra-home rule 20 action 'accept'
-set firewall ipv4 name infra-home rule 20 description 'Rule: Accept_HTTPS'
-set firewall ipv4 name infra-home rule 20 destination port '443'
-set firewall ipv4 name infra-home rule 20 protocol 'tcp'
 ### --- 999-home : Drop Invalid Packets
 set firewall ipv4 name infra-home rule 999 action 'drop'
 set firewall ipv4 name infra-home rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name infra-home rule 999 log 'enable'
-set firewall ipv4 name infra-home rule 999 state invalid 'enable'
+set firewall ipv4 name infra-home rule 999 log
+set firewall ipv4 name infra-home rule 999 state invalid
 
 # (30) From infra to iot
 set firewall ipv4 name infra-iot default-action 'drop'
@@ -44,8 +39,8 @@ set firewall ipv4 name infra-iot rule 10 protocol 'tcp'
 ### --- 999-iot : Drop Invalid Packets
 set firewall ipv4 name infra-iot rule 999 action 'drop'
 set firewall ipv4 name infra-iot rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name infra-iot rule 999 log 'enable'
-set firewall ipv4 name infra-iot rule 999 state invalid 'enable'
+set firewall ipv4 name infra-iot rule 999 log
+set firewall ipv4 name infra-iot rule 999 state invalid
 
 # (40) From infra to cctv
 set firewall ipv4 name infra-cctv default-action 'drop'
@@ -59,8 +54,8 @@ set firewall ipv4 name infra-cctv rule 10 protocol 'tcp'
 ### --- 999-cctv : Drop Invalid Packets
 set firewall ipv4 name infra-cctv rule 999 action 'drop'
 set firewall ipv4 name infra-cctv rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name infra-cctv rule 999 log 'enable'
-set firewall ipv4 name infra-cctv rule 999 state invalid 'enable'
+set firewall ipv4 name infra-cctv rule 999 log
+set firewall ipv4 name infra-cctv rule 999 state invalid
 
 # (97) From infra to containers
 set firewall ipv4 name infra-containers default-action 'accept'
@@ -73,8 +68,8 @@ set firewall ipv4 name infra-containers rule 10 protocol 'tcp_udp'
 ### --- 999-containers : Drop Invalid Packets
 set firewall ipv4 name infra-containers rule 999 action 'drop'
 set firewall ipv4 name infra-containers rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name infra-containers rule 999 log 'enable'
-set firewall ipv4 name infra-containers rule 999 state invalid 'enable'
+set firewall ipv4 name infra-containers rule 999 log
+set firewall ipv4 name infra-containers rule 999 state invalid
 
 # (98) From infra to local
 set firewall ipv4 name infra-local default-action 'drop'
@@ -87,37 +82,37 @@ set firewall ipv4 name infra-local rule 10 destination port '67,68'
 set firewall ipv4 name infra-local rule 10 protocol 'udp'
 set firewall ipv4 name infra-local rule 10 source port '67,68'
 ### --- 020-local : Accept NTP Traffic (123/udp)
-set firewall ipv4 name infra-local rule 20 action 'accept'
-set firewall ipv4 name infra-local rule 20 description 'Rule: Accept_NTP'
-set firewall ipv4 name infra-local rule 20 destination port 'ntp'
-set firewall ipv4 name infra-local rule 20 protocol 'udp'
+set firewall ipv4 name infra-local rule 11 action 'accept'
+set firewall ipv4 name infra-local rule 11 description 'Rule: Accept_NTP'
+set firewall ipv4 name infra-local rule 11 destination port 'ntp'
+set firewall ipv4 name infra-local rule 11 protocol 'udp'
 ### --- 030-local : Accept BGP Traffic (179/tcp)
-set firewall ipv4 name infra-local rule 30 action 'accept'
-set firewall ipv4 name infra-local rule 30 description 'Rule: Accept_BGP'
-set firewall ipv4 name infra-local rule 30 destination port 'bgp'
-set firewall ipv4 name infra-local rule 30 protocol 'tcp'
+set firewall ipv4 name infra-local rule 12 action 'accept'
+set firewall ipv4 name infra-local rule 12  description 'Rule: Accept_BGP'
+set firewall ipv4 name infra-local rule 12 destination port 'bgp'
+set firewall ipv4 name infra-local rule 12 protocol 'tcp'
 ### --- 040-local : Accept TFTP Traffic (69/udp)
-set firewall ipv4 name infra-local rule 40 action 'accept'
-set firewall ipv4 name infra-local rule 40 description 'Rule: Accept_TFTP'
-set firewall ipv4 name infra-local rule 40 destination port '69'
-set firewall ipv4 name infra-local rule 40 protocol 'udp'
+set firewall ipv4 name infra-local rule 13 action 'accept'
+set firewall ipv4 name infra-local rule 13 description 'Rule: Accept_TFTP'
+set firewall ipv4 name infra-local rule 13 destination port '69'
+set firewall ipv4 name infra-local rule 13 protocol 'udp'
 ### --- 050-local : Accept Prometheus Exporter from K8S Nodes Traffic (9100/tcp)
-set firewall ipv4 name infra-local rule 50 action 'accept'
-set firewall ipv4 name infra-local rule 50 description 'Rule: Accept_Prometheus_from_k8s'
-set firewall ipv4 name infra-local rule 50 destination port '9100'
-set firewall ipv4 name infra-local rule 50 protocol 'tcp'
-set firewall ipv4 name infra-local rule 50 source group address-group 'k8s_nodes'
+set firewall ipv4 name infra-local rule 14 action 'accept'
+set firewall ipv4 name infra-local rule 14 description 'Rule: Accept_Prometheus_from_k8s'
+set firewall ipv4 name infra-local rule 14 destination port '9100'
+set firewall ipv4 name infra-local rule 14 protocol 'tcp'
+set firewall ipv4 name infra-local rule 14 source group address-group 'k8s_nodes'
 ### --- 060-local : Accept Speedtest Exporter from K8S Nodes Traffic (9798/tcp)
-set firewall ipv4 name infra-local rule 50 action 'accept'
-set firewall ipv4 name infra-local rule 50 description 'Rule: Accept_Prometheus_from_k8s'
-set firewall ipv4 name infra-local rule 50 destination port '9798'
-set firewall ipv4 name infra-local rule 50 protocol 'tcp'
-set firewall ipv4 name infra-local rule 50 source group address-group 'k8s_nodes'
+set firewall ipv4 name infra-local rule 15 action 'accept'
+set firewall ipv4 name infra-local rule 15 description 'Rule: Accept_Prometheus_from_k8s'
+set firewall ipv4 name infra-local rule 15 destination port '9798'
+set firewall ipv4 name infra-local rule 15 protocol 'tcp'
+set firewall ipv4 name infra-local rule 15 source group address-group 'k8s_nodes'
 ### --- 999-local : Drop Invalid Packets
 set firewall ipv4 name infra-local rule 999 action 'drop'
 set firewall ipv4 name infra-local rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name infra-local rule 999 log 'enable'
-set firewall ipv4 name infra-local rule 999 state invalid 'enable'
+set firewall ipv4 name infra-local rule 999 log
+set firewall ipv4 name infra-local rule 999 state invalid
 
 # (99) From infra to wan
 set firewall ipv4 name infra-wan default-action 'accept'

--- a/config-parts/fw-20-home.sh
+++ b/config-parts/fw-20-home.sh
@@ -5,25 +5,25 @@
 #### home ----------------------------------------------------------------------------
 # (00) From home to management
 set firewall ipv4 name home-mgmt default-action 'drop'
-set firewall ipv4 name home-mgmt description 'From infra to mgmt'
+set firewall ipv4 name home-mgmt description 'From home to mgmt'
 set firewall ipv4 name home-mgmt enable-default-log
 ### --- 010-mgmt : Accept HTTP-HTTPS Traffic from Trusted MAC (80/443)
 set firewall ipv4 name home-mgmt rule 10 action 'accept'
 set firewall ipv4 name home-mgmt rule 10 description 'Rule: Accept_HTTPS-HTTPS_From_Trusted_MAC'
-set firewall ipv4 name home-mgmt rule 10 destination port '80,443'
+set firewall ipv4 name home-mgmt rule 10 destination port 'http,https'
 set firewall ipv4 name home-mgmt rule 10 protocol 'tcp'
 set firewall ipv4 name home-mgmt rule 10 source group mac-group 'trusted_mac'
-### --- 020-mgmt : Accept SSH Traffic from Trusted MAC (22)
-set firewall ipv4 name home-mgmt rule 20 action 'accept'
-set firewall ipv4 name home-mgmt rule 20 description 'Rule: Accept_SSH_From_Trusted_MAC'
-set firewall ipv4 name home-mgmt rule 20 destination port '22'
-set firewall ipv4 name home-mgmt rule 20 protocol 'tcp'
-set firewall ipv4 name home-mgmt rule 20 source group mac-group 'trusted_mac'
+### --- 011-mgmt : Accept SSH Traffic from Trusted MAC (22)
+set firewall ipv4 name home-mgmt rule 11 action 'accept'
+set firewall ipv4 name home-mgmt rule 11 description 'Rule: Accept_SSH_From_Trusted_MAC'
+set firewall ipv4 name home-mgmt rule 11 destination port '22'
+set firewall ipv4 name home-mgmt rule 11 protocol 'tcp'
+set firewall ipv4 name home-mgmt rule 11 source group mac-group 'trusted_mac'
 ### --- 999-mgmt : Drop Invalid Packets
 set firewall ipv4 name home-mgmt rule 999 action 'drop'
 set firewall ipv4 name home-mgmt rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name home-mgmt rule 999 log 'enable'
-set firewall ipv4 name home-mgmt rule 999 state invalid 'enable'
+set firewall ipv4 name home-mgmt rule 999 log
+set firewall ipv4 name home-mgmt rule 999 state invalid
 
 # (10) From home to infra
 set firewall ipv4 name home-infra default-action 'drop'
@@ -32,25 +32,25 @@ set firewall ipv4 name home-infra enable-default-log
 ### --- 010-infra : Accept HTTP-HTTPS Traffic (80/443)
 set firewall ipv4 name home-infra rule 10 action 'accept'
 set firewall ipv4 name home-infra rule 10 description 'Rule: Accept_HTTP_HTTPS'
-set firewall ipv4 name home-infra rule 10 destination port '80,443'
+set firewall ipv4 name home-infra rule 10 destination port 'http,https'
 set firewall ipv4 name home-infra rule 10 protocol 'tcp'
-### --- 020-infra : Accept K8S API Traffic from trusted MAC group (6443)
-set firewall ipv4 name home-infra rule 20 action 'accept'
-set firewall ipv4 name home-infra rule 20 description 'Rule: Accept_K8S_API_From_Trusted_MAC'
-set firewall ipv4 name home-infra rule 20 destination port '6443'
-set firewall ipv4 name home-infra rule 20 protocol 'tcp'
-set firewall ipv4 name home-infra rule 20 source group mac-group 'trusted_mac'
-### --- 030-infra : Accept Talos API Traffic from trusted MAC group (50000)
-set firewall ipv4 name home-infra rule 30 action 'accept'
-set firewall ipv4 name home-infra rule 30 description 'Rule: Accept_Talos_API_From_Trusted_MAC'
-set firewall ipv4 name home-infra rule 30 destination port '5000'
-set firewall ipv4 name home-infra rule 30 protocol 'tcp'
-set firewall ipv4 name home-infra rule 30 source group mac-group 'trusted_mac'
+### --- 011-infra : Accept K8S API Traffic from trusted MAC group (6443)
+set firewall ipv4 name home-infra rule 11 action 'accept'
+set firewall ipv4 name home-infra rule 11 description 'Rule: Accept_K8S_API_From_Trusted_MAC'
+set firewall ipv4 name home-infra rule 11 destination port '6443'
+set firewall ipv4 name home-infra rule 11 protocol 'tcp'
+set firewall ipv4 name home-infra rule 11 source group mac-group 'trusted_mac'
+### --- 012-infra : Accept Talos API Traffic from trusted MAC group (50000)
+set firewall ipv4 name home-infra rule 12 action 'accept'
+set firewall ipv4 name home-infra rule 12 description 'Rule: Accept_Talos_API_From_Trusted_MAC'
+set firewall ipv4 name home-infra rule 12 destination port '50000'
+set firewall ipv4 name home-infra rule 12 protocol 'tcp'
+set firewall ipv4 name home-infra rule 12 source group mac-group 'trusted_mac'
 ### --- 999-infra : Drop Invalid Packets
 set firewall ipv4 name home-infra rule 999 action 'drop'
 set firewall ipv4 name home-infra rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name home-infra rule 999 log 'enable'
-set firewall ipv4 name home-infra rule 999 state invalid 'enable'
+set firewall ipv4 name home-infra rule 999 log
+set firewall ipv4 name home-infra rule 999 state invalid
 
 # (30) From home to iot
 set firewall ipv4 name home-iot default-action 'drop'
@@ -59,13 +59,13 @@ set firewall ipv4 name home-iot enable-default-log
 ### --- 010-iot : Accept HTTP-HTTPS Traffic (80/443)
 set firewall ipv4 name home-iot rule 10 action 'accept'
 set firewall ipv4 name home-iot rule 10 description 'Rule: Accept_HTTP_HTTPS'
-set firewall ipv4 name home-iot rule 10 destination port '80,443'
+set firewall ipv4 name home-iot rule 10 destination port 'http,https'
 set firewall ipv4 name home-iot rule 10 protocol 'tcp'
 ### --- 999-iot : Drop Invalid Packets
 set firewall ipv4 name home-iot rule 999 action 'drop'
 set firewall ipv4 name home-iot rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name home-iot rule 999 log 'enable'
-set firewall ipv4 name home-iot rule 999 state invalid 'enable'
+set firewall ipv4 name home-iot rule 999 log
+set firewall ipv4 name home-iot rule 999 state invalid
 
 # (40) From home to cctv
 set firewall ipv4 name home-cctv default-action 'drop'
@@ -74,13 +74,18 @@ set firewall ipv4 name home-cctv enable-default-log
 ### --- 010-cctv : Accept HTTP-HTTPS Traffic (80/443)
 set firewall ipv4 name home-cctv rule 10 action 'accept'
 set firewall ipv4 name home-cctv rule 10 description 'Rule: Accept_HTTP_HTTPS'
-set firewall ipv4 name home-cctv rule 10 destination port '80,443'
+set firewall ipv4 name home-cctv rule 10 destination port 'http,https'
 set firewall ipv4 name home-cctv rule 10 protocol 'tcp'
+### --- 011-cctv : Accept RTSP:554 Traffic (554 tcp/udp)
+set firewall ipv4 name home-cctv rule 11 action 'accept'
+set firewall ipv4 name home-cctv rule 11 description 'Rule: Accept_RTSP_554'
+set firewall ipv4 name home-cctv rule 11 destination port '554'
+set firewall ipv4 name home-cctv rule 11 protocol 'tcp_udp' 
 ### --- 999-cctv : Drop Invalid Packets
 set firewall ipv4 name home-cctv rule 999 action 'drop'
 set firewall ipv4 name home-cctv rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name home-cctv rule 999 log 'enable'
-set firewall ipv4 name home-cctv rule 999 state invalid 'enable'
+set firewall ipv4 name home-cctv rule 999 log
+set firewall ipv4 name home-cctv rule 999 state invalid
 
 # (97) From home to containers
 set firewall ipv4 name home-containers default-action 'drop'
@@ -91,29 +96,32 @@ set firewall ipv4 name home-containers rule 10 action 'accept'
 set firewall ipv4 name home-containers rule 10 description 'Rule: Accept_DNS'
 set firewall ipv4 name home-containers rule 10 destination port 'domain,domain-s'
 set firewall ipv4 name home-containers rule 10 protocol 'tcp_udp'
-### --- 020-containers : Accept 1passconnect connect from Trusted MAC (8080)
-set firewall ipv4 name home-containers rule 20 action 'accept'
-set firewall ipv4 name home-containers rule 20 description 'Rule: Accept_1PassConnect_From_Trusted_MAC'
-set firewall ipv4 name home-containers rule 20 destination port '8080'
-set firewall ipv4 name home-containers rule 20 protocol 'tcp'
-set firewall ipv4 name home-containers rule 20 source group mac-group 'trusted_mac'
-### --- 030-containers : Accept HTTP-HTTPS Traffic from Trusted MAC (80/443)
-set firewall ipv4 name home-containers rule 30 action 'accept'
-set firewall ipv4 name home-containers rule 30 description 'Rule: Accept_HTTPS-HTTPS_From_Trusted_MAC'
-set firewall ipv4 name home-containers rule 30 destination port '80,443'
-set firewall ipv4 name home-containers rule 30 protocol 'tcp'
-set firewall ipv4 name home-containers rule 30 source group mac-group 'trusted_mac'
-### --- 040-containers : Accept HAPROXY Stat Traffic from Trusted MAC (9000)
-set firewall ipv4 name home-containers rule 40 action 'accept'
-set firewall ipv4 name home-containers rule 40 description 'Rule: Accept_LB_Stats_From_Trusted_MAC'
-set firewall ipv4 name home-containers rule 40 destination port '9000'
-set firewall ipv4 name home-containers rule 40 protocol 'tcp'
-set firewall ipv4 name home-containers rule 40 source group mac-group 'trusted_mac'
+set firewall ipv4 name home-containers rule 10 destination group address-group 'dns_svc'
+### --- 011-containers : Accept 1passconnect connect from Trusted MAC (8080)
+set firewall ipv4 name home-containers rule 11 action 'accept'
+set firewall ipv4 name home-containers rule 11 description 'Rule: Accept_1PassConnect_From_Trusted_MAC'
+set firewall ipv4 name home-containers rule 11 destination port '8080'
+set firewall ipv4 name home-containers rule 11 destination group address-group 'vyos_1passconnect'
+set firewall ipv4 name home-containers rule 11 protocol 'tcp'
+set firewall ipv4 name home-containers rule 11 source group mac-group 'trusted_mac'
+### --- 012-containers : Accept HTTP-HTTPS Traffic from Trusted MAC (80/443)
+set firewall ipv4 name home-containers rule 12 action 'accept'
+set firewall ipv4 name home-containers rule 12 description 'Rule: Accept_HTTPS-HTTPS_From_Trusted_MAC'
+set firewall ipv4 name home-containers rule 12 destination port 'http,https'
+set firewall ipv4 name home-containers rule 12 protocol 'tcp'
+set firewall ipv4 name home-containers rule 12 source group mac-group 'trusted_mac'
+### --- 013-containers : Accept HAPROXY Stat Traffic from Trusted MAC (9000)
+set firewall ipv4 name home-containers rule 13 action 'accept'
+set firewall ipv4 name home-containers rule 13 description 'Rule: Accept_LB_Stats_From_Trusted_MAC'
+set firewall ipv4 name home-containers rule 13 destination port '9000'
+set firewall ipv4 name home-containers rule 13 destination group address-group 'vyos_haproxy'
+set firewall ipv4 name home-containers rule 13 protocol 'tcp'
+set firewall ipv4 name home-containers rule 13 source group mac-group 'trusted_mac'
 ### --- 999-containers : Drop Invalid Packets
 set firewall ipv4 name home-containers rule 999 action 'drop'
 set firewall ipv4 name home-containers rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name home-containers rule 999 log 'enable'
-set firewall ipv4 name home-containers rule 999 state invalid 'enable'
+set firewall ipv4 name home-containers rule 999 log
+set firewall ipv4 name home-containers rule 999 state invalid
 
 # (98) From home to local
 set firewall ipv4 name home-local default-action 'drop'
@@ -125,23 +133,22 @@ set firewall ipv4 name home-local rule 10 description 'Rule: Accept_DHCP'
 set firewall ipv4 name home-local rule 10 destination port '67,68'
 set firewall ipv4 name home-local rule 10 protocol 'udp'
 set firewall ipv4 name home-local rule 10 source port '67,68'
-### --- 020-local : Accept NTP Traffic (123/udp)
-set firewall ipv4 name home-local rule 20 action 'accept'
-set firewall ipv4 name home-local rule 20 description 'Rule: Accept_NTP'
-set firewall ipv4 name home-local rule 20 destination port 'ntp'
-set firewall ipv4 name home-local rule 20 protocol 'udp'
-### --- 030-local : Accept SSH Traffic from Trusted MAC (22)
-set firewall ipv4 name home-local rule 30 action 'accept'
-set firewall ipv4 name home-local rule 30 description 'Rule: Accept_SSH_From_Trusted_MAC'
-set firewall ipv4 name home-local rule 30 destination port '22'
-set firewall ipv4 name home-local rule 30 protocol 'tcp'
-set firewall ipv4 name home-local rule 30 source group mac-group 'trusted_mac'
+### --- 011-local : Accept NTP Traffic (123/udp)
+set firewall ipv4 name home-local rule 11 action 'accept'
+set firewall ipv4 name home-local rule 11 description 'Rule: Accept_NTP'
+set firewall ipv4 name home-local rule 11 destination port 'ntp'
+set firewall ipv4 name home-local rule 11 protocol 'udp'
+### --- 012-local : Accept SSH Traffic from Trusted MAC (22)
+set firewall ipv4 name home-local rule 12 action 'accept'
+set firewall ipv4 name home-local rule 12 description 'Rule: Accept_SSH_From_Trusted_MAC'
+set firewall ipv4 name home-local rule 12 destination port '22'
+set firewall ipv4 name home-local rule 12 protocol 'tcp'
+set firewall ipv4 name home-local rule 12 source group mac-group 'trusted_mac'
 ### --- 999-local : Drop Invalid Packets
 set firewall ipv4 name home-local rule 999 action 'drop'
 set firewall ipv4 name home-local rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name home-local rule 999 log 'enable'
-set firewall ipv4 name home-local rule 999 state invalid 'enable'
-
+set firewall ipv4 name home-local rule 999 log
+set firewall ipv4 name home-local rule 999 state invalid
 # (99) From home to wan
 set firewall ipv4 name home-wan default-action 'accept'
 set firewall ipv4 name home-wan description 'From home to wan'

--- a/config-parts/fw-30-iot.sh
+++ b/config-parts/fw-30-iot.sh
@@ -10,8 +10,8 @@ set firewall ipv4 name iot-mgmt enable-default-log
 ### --- 999-mgmt : Drop Invalid Packets
 set firewall ipv4 name iot-mgmt rule 999 action 'drop'
 set firewall ipv4 name iot-mgmt rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name iot-mgmt rule 999 log 'enable'
-set firewall ipv4 name iot-mgmt rule 999 state invalid 'enable'
+set firewall ipv4 name iot-mgmt rule 999 log
+set firewall ipv4 name iot-mgmt rule 999 state invalid
 
 # (10) From iot to infra
 set firewall ipv4 name iot-infra default-action 'drop'
@@ -22,16 +22,16 @@ set firewall ipv4 name iot-infra rule 10 action 'accept'
 set firewall ipv4 name iot-infra rule 10 description 'Rule: Accept_MQTT'
 set firewall ipv4 name iot-infra rule 10 destination port '1883'
 set firewall ipv4 name iot-infra rule 10 protocol 'tcp'
-### ---20-infra: Accept HTTP/HTTPS Traffic (80/443)
-set firewall ipv4 name iot-infra rule 20 action 'accept'
-set firewall ipv4 name iot-infra rule 20 description 'Rule: Accept_HTTP_HTTPS'
-set firewall ipv4 name iot-infra rule 20 destination port 'http,https'
-set firewall ipv4 name iot-infra rule 20 protocol 'tcp'
+### ---11-infra: Accept HTTP/HTTPS Traffic (80/443)
+set firewall ipv4 name iot-infra rule 11 action 'accept'
+set firewall ipv4 name iot-infra rule 11 description 'Rule: Accept_HTTP_HTTPS'
+set firewall ipv4 name iot-infra rule 11 destination port 'http,https'
+set firewall ipv4 name iot-infra rule 11 protocol 'tcp'
 ### --- 999-infra : Drop Invalid Packets
 set firewall ipv4 name iot-infra rule 999 action 'drop'
 set firewall ipv4 name iot-infra rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name iot-infra rule 999 log 'enable'
-set firewall ipv4 name iot-infra rule 999 state invalid 'enable'
+set firewall ipv4 name iot-infra rule 999 log
+set firewall ipv4 name iot-infra rule 999 state invalid
 
 # (20) From iot to home
 set firewall ipv4 name iot-home default-action 'drop'
@@ -40,8 +40,8 @@ set firewall ipv4 name iot-home enable-default-log
 ### --- 999-home : Drop Invalid Packets
 set firewall ipv4 name iot-home rule 999 action 'drop'
 set firewall ipv4 name iot-home rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name iot-home rule 999 log 'enable'
-set firewall ipv4 name iot-home rule 999 state invalid 'enable'
+set firewall ipv4 name iot-home rule 999 log
+set firewall ipv4 name iot-home rule 999 state invalid
 
 # (40) From iot to cctv
 set firewall ipv4 name iot-cctv default-action 'drop'
@@ -50,8 +50,8 @@ set firewall ipv4 name iot-cctv enable-default-log
 ### --- 999-cctv : Drop Invalid Packets
 set firewall ipv4 name iot-cctv rule 999 action 'drop'
 set firewall ipv4 name iot-cctv rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name iot-cctv rule 999 log 'enable'
-set firewall ipv4 name iot-cctv rule 999 state invalid 'enable'
+set firewall ipv4 name iot-cctv rule 999 log
+set firewall ipv4 name iot-cctv rule 999 state invalid
 
 # (97) From iot to containers
 set firewall ipv4 name iot-containers default-action 'drop'
@@ -61,12 +61,13 @@ set firewall ipv4 name iot-containers enable-default-log
 set firewall ipv4 name iot-containers rule 10 action 'accept'
 set firewall ipv4 name iot-containers rule 10 description 'Rule: Accept_DNS'
 set firewall ipv4 name iot-containers rule 10 destination port 'domain,domain-s'
+set firewall ipv4 name iot-containers rule 10 destination group address-group 'dns_svc' 
 set firewall ipv4 name iot-containers rule 10 protocol 'tcp_udp'
 ### --- 999-containers : Drop Invalid Packets
 set firewall ipv4 name iot-containers rule 999 action 'drop'
 set firewall ipv4 name iot-containers rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name iot-containers rule 999 log 'enable'
-set firewall ipv4 name iot-containers rule 999 state invalid 'enable'
+set firewall ipv4 name iot-containers rule 999 log
+set firewall ipv4 name iot-containers rule 999 state invalid
 
 # (98) From iot to local
 set firewall ipv4 name iot-local default-action 'drop'
@@ -78,16 +79,16 @@ set firewall ipv4 name iot-local rule 10 description 'Rule: Accept_DHCP'
 set firewall ipv4 name iot-local rule 10 destination port '67,68'
 set firewall ipv4 name iot-local rule 10 protocol 'udp'
 set firewall ipv4 name iot-local rule 10 source port '67,68'
-### --- 020-local : Accept NTP Traffic (123/udp)
-set firewall ipv4 name iot-local rule 20 action 'accept'
-set firewall ipv4 name iot-local rule 20 description 'Rule: Accept_NTP'
-set firewall ipv4 name iot-local rule 20 destination port 'ntp'
-set firewall ipv4 name iot-local rule 20 protocol 'udp'
+### --- 011-local : Accept NTP Traffic (123/udp)
+set firewall ipv4 name iot-local rule 11 action 'accept'
+set firewall ipv4 name iot-local rule 11 description 'Rule: Accept_NTP'
+set firewall ipv4 name iot-local rule 11 destination port 'ntp'
+set firewall ipv4 name iot-local rule 11 protocol 'udp'
 ### --- 999-local : Drop Invalid Packets
 set firewall ipv4 name iot-local rule 999 action 'drop'
 set firewall ipv4 name iot-local rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name iot-local rule 999 log 'enable'
-set firewall ipv4 name iot-local rule 999 state invalid 'enable'
+set firewall ipv4 name iot-local rule 999 log
+set firewall ipv4 name iot-local rule 999 state invalid
 
 # (99) From iot to wan
 set firewall ipv4 name iot-wan default-action 'accept'

--- a/config-parts/fw-40-cctv.sh
+++ b/config-parts/fw-40-cctv.sh
@@ -10,8 +10,8 @@ set firewall ipv4 name cctv-mgmt enable-default-log
 ### --- 999-mgmt : Drop Invalid Packets
 set firewall ipv4 name cctv-mgmt rule 999 action 'drop'
 set firewall ipv4 name cctv-mgmt rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name cctv-mgmt rule 999 log 'enable'
-set firewall ipv4 name cctv-mgmt rule 999 state invalid 'enable'
+set firewall ipv4 name cctv-mgmt rule 999 log 
+set firewall ipv4 name cctv-mgmt rule 999 state invalid
 
 # (10) From cctv to infra
 set firewall ipv4 name cctv-infra default-action 'drop'
@@ -20,8 +20,8 @@ set firewall ipv4 name cctv-infra enable-default-log
 ### --- 999-infra : Drop Invalid Packets
 set firewall ipv4 name cctv-infra rule 999 action 'drop'
 set firewall ipv4 name cctv-infra rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name cctv-infra rule 999 log 'enable'
-set firewall ipv4 name cctv-infra rule 999 state invalid 'enable'
+set firewall ipv4 name cctv-infra rule 999 log
+set firewall ipv4 name cctv-infra rule 999 state invalid
 
 # (20) From cctv to home
 set firewall ipv4 name cctv-home default-action 'drop'
@@ -30,8 +30,8 @@ set firewall ipv4 name cctv-home enable-default-log
 ### --- 999-home : Drop Invalid Packets
 set firewall ipv4 name cctv-home rule 999 action 'drop'
 set firewall ipv4 name cctv-home rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name cctv-home rule 999 log 'enable'
-set firewall ipv4 name cctv-home rule 999 state invalid 'enable'
+set firewall ipv4 name cctv-home rule 999 log
+set firewall ipv4 name cctv-home rule 999 state invalid
 
 # (30) From cctv to iot
 set firewall ipv4 name cctv-iot default-action 'drop'
@@ -40,8 +40,8 @@ set firewall ipv4 name cctv-iot enable-default-log
 ### --- 999-iot : Drop Invalid Packets
 set firewall ipv4 name cctv-iot rule 999 action 'drop'
 set firewall ipv4 name cctv-iot rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name cctv-iot rule 999 log 'enable'
-set firewall ipv4 name cctv-iot rule 999 state invalid 'enable'
+set firewall ipv4 name cctv-iot rule 999 log
+set firewall ipv4 name cctv-iot rule 999 state invalid
 
 # (97) From cctv to containers
 set firewall ipv4 name cctv-containers default-action 'drop'
@@ -51,12 +51,13 @@ set firewall ipv4 name cctv-containers enable-default-log
 set firewall ipv4 name cctv-containers rule 10 action 'accept'
 set firewall ipv4 name cctv-containers rule 10 description 'Rule: Accept_DNS'
 set firewall ipv4 name cctv-containers rule 10 destination port 'domain,domain-s'
+set firewall ipv4 name cctv-containers rule 10 destination group address-group 'dns_svc' 
 set firewall ipv4 name cctv-containers rule 10 protocol 'tcp_udp'
 ### --- 999-containers : Drop Invalid Packets
 set firewall ipv4 name cctv-containers rule 999 action 'drop'
 set firewall ipv4 name cctv-containers rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name cctv-containers rule 999 log 'enable'
-set firewall ipv4 name cctv-containers rule 999 state invalid 'enable'
+set firewall ipv4 name cctv-containers rule 999 log
+set firewall ipv4 name cctv-containers rule 999 state invalid
 
 # (98) From cctv to local
 set firewall ipv4 name cctv-local default-action 'drop'
@@ -68,16 +69,16 @@ set firewall ipv4 name cctv-local rule 10 description 'Rule: Accept_DHCP'
 set firewall ipv4 name cctv-local rule 10 destination port '67,68'
 set firewall ipv4 name cctv-local rule 10 protocol 'udp'
 set firewall ipv4 name cctv-local rule 10 source port '67,68'
-### --- 020-local : Accept NTP Traffic (123/udp)
-set firewall ipv4 name cctv-local rule 20 action 'accept'
-set firewall ipv4 name cctv-local rule 20 description 'Rule: Accept_NTP'
-set firewall ipv4 name cctv-local rule 20 destination port 'ntp'
-set firewall ipv4 name cctv-local rule 20 protocol 'udp'
+### --- 011-local : Accept NTP Traffic (123/udp)
+set firewall ipv4 name cctv-local rule 11 action 'accept'
+set firewall ipv4 name cctv-local rule 11 description 'Rule: Accept_NTP'
+set firewall ipv4 name cctv-local rule 11 destination port 'ntp'
+set firewall ipv4 name cctv-local rule 11 protocol 'udp'
 ### --- 999-local : Drop Invalid Packets
 set firewall ipv4 name cctv-local rule 999 action 'drop'
 set firewall ipv4 name cctv-local rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name cctv-local rule 999 log 'enable'
-set firewall ipv4 name cctv-local rule 999 state invalid 'enable'
+set firewall ipv4 name cctv-local rule 999 log
+set firewall ipv4 name cctv-local rule 999 state invalid
 
 # (99) From cctv to wan
 set firewall ipv4 name cctv-wan default-action 'accept'

--- a/config-parts/fw-97-containers.sh
+++ b/config-parts/fw-97-containers.sh
@@ -10,17 +10,31 @@ set firewall ipv4 name containers-mgmt enable-default-log
 ### --- 999-mgmt : Drop Invalid Packets
 set firewall ipv4 name containers-mgmt rule 999 action 'drop'
 set firewall ipv4 name containers-mgmt rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name containers-mgmt rule 999 log 'enable'
-set firewall ipv4 name containers-mgmt rule 999 state invalid 'enable'
+set firewall ipv4 name containers-mgmt rule 999 log
+set firewall ipv4 name containers-mgmt rule 999 state invalid
 
 # (10) From containers to infra
 set firewall ipv4 name containers-infra default-action 'accept'
 set firewall ipv4 name containers-infra description 'From containers to infra'
+### --- 010-infra : Accept K8S-API From HAPROXY (6443/tcp)
+set firewall ipv4 name containers-infra rule 10 action 'accept'
+set firewall ipv4 name containers-infra rule 10 description 'Rule: Accept_K8S_API_From_HAPROXY'
+set firewall ipv4 name containers-infra rule 10 destination port '6443'
+set firewall ipv4 name containers-infra rule 10 protocol 'tcp'
+set firewall ipv4 name containers-infra rule 10 source group address-group 'vyos_haproxy'
+set firewall ipv4 name containers-infra rule 10 destination group address-group 'k8s_nodes'
+### --- 011-infra : Accept Talos API From HAPROXY (50000/tcp)
+set firewall ipv4 name containers-infra rule 11 action 'accept'
+set firewall ipv4 name containers-infra rule 11 description 'Rule: Accept_Talos_API_From_HAPROXY'
+set firewall ipv4 name containers-infra rule 11 destination port '50000'
+set firewall ipv4 name containers-infra rule 11 protocol 'tcp'
+set firewall ipv4 name containers-infra rule 11 source group address-group 'vyos_haproxy'
+set firewall ipv4 name containers-infra rule 11 destination group address-group 'k8s_nodes'
 ### --- 999-infra : Drop Invalid Packets
 set firewall ipv4 name containers-infra rule 999 action 'drop'
 set firewall ipv4 name containers-infra rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name containers-infra rule 999 log 'enable'
-set firewall ipv4 name containers-infra rule 999 state invalid 'enable'
+set firewall ipv4 name containers-infra rule 999 log
+set firewall ipv4 name containers-infra rule 999 state invalid
 
 # (20) From containers to home
 set firewall ipv4 name containers-home default-action 'drop'
@@ -29,8 +43,8 @@ set firewall ipv4 name containers-home enable-default-log
 ### --- 999-home : Drop Invalid Packets
 set firewall ipv4 name containers-home rule 999 action 'drop'
 set firewall ipv4 name containers-home rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name containers-home rule 999 log 'enable'
-set firewall ipv4 name containers-home rule 999 state invalid 'enable'
+set firewall ipv4 name containers-home rule 999 log
+set firewall ipv4 name containers-home rule 999 state invalid
 
 # (30) From containers to iot
 set firewall ipv4 name containers-iot default-action 'drop'
@@ -39,18 +53,18 @@ set firewall ipv4 name containers-iot enable-default-log
 ### --- 999-iot : Drop Invalid Packets
 set firewall ipv4 name containers-iot rule 999 action 'drop'
 set firewall ipv4 name containers-iot rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name containers-iot rule 999 log 'enable'
-set firewall ipv4 name containers-iot rule 999 state invalid 'enable'
+set firewall ipv4 name containers-iot rule 999 log
+set firewall ipv4 name containers-iot rule 999 state invalid
 
 # (40) From containers to cctv
-set firewall ipv4 name iot-containers default-action 'drop'
-set firewall ipv4 name iot-containers description 'From iot to containers'
-set firewall ipv4 name iot-containers enable-default-log
+set firewall ipv4 name containers-cctv default-action 'drop'
+set firewall ipv4 name containers-cctv description 'From containers to cctv'
+set firewall ipv4 name containers-cctv enable-default-log
 ### --- 999-cctv : Drop Invalid Packets
-set firewall ipv4 name iot-containers rule 999 action 'drop'
-set firewall ipv4 name iot-containers rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name iot-containers rule 999 log 'enable'
-set firewall ipv4 name iot-containers rule 999 state invalid 'enable'
+set firewall ipv4 name containers-cctv rule 999 action 'drop'
+set firewall ipv4 name containers-cctv rule 999 description 'Rule: Drop_Invalid'
+set firewall ipv4 name containers-cctv rule 999 log
+set firewall ipv4 name containers-cctv rule 999 state invalid
 
 # (98) From containers to local
 set firewall ipv4 name containers-local default-action 'drop'
@@ -62,16 +76,16 @@ set firewall ipv4 name containers-local rule 10 description 'Rule: Accept_DHCP'
 set firewall ipv4 name containers-local rule 10 destination port '67,68'
 set firewall ipv4 name containers-local rule 10 protocol 'udp'
 set firewall ipv4 name containers-local rule 10 source port '67,68'
-### --- 020-local : Accept NTP Traffic (123/udp)
-set firewall ipv4 name containers-local rule 20 action 'accept'
-set firewall ipv4 name containers-local rule 20 description 'Rule: Accept_NTP'
-set firewall ipv4 name containers-local rule 20 destination port 'ntp'
-set firewall ipv4 name containers-local rule 20 protocol 'udp'
+### --- 011-local : Accept NTP Traffic (123/udp)
+set firewall ipv4 name containers-local rule 11 action 'accept'
+set firewall ipv4 name containers-local rule 11 description 'Rule: Accept_NTP'
+set firewall ipv4 name containers-local rule 11 destination port 'ntp'
+set firewall ipv4 name containers-local rule 11 protocol 'udp'
 ### --- 999-local : Drop Invalid Packets
 set firewall ipv4 name containers-local rule 999 action 'drop'
 set firewall ipv4 name containers-local rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name containers-local rule 999 log 'enable'
-set firewall ipv4 name containers-local rule 999 state invalid 'enable'
+set firewall ipv4 name containers-local rule 999 log
+set firewall ipv4 name containers-local rule 999 state invalid
 
 # (99) From containers to wan
 set firewall ipv4 name containers-wan default-action 'accept'

--- a/config-parts/fw-98-local.sh
+++ b/config-parts/fw-98-local.sh
@@ -10,8 +10,8 @@ set firewall ipv4 name local-mgmt enable-default-log
 ### --- 999-mgmt : Drop Invalid Packets
 set firewall ipv4 name local-mgmt rule 999 action 'drop'
 set firewall ipv4 name local-mgmt rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name local-mgmt rule 999 log 'enable'
-set firewall ipv4 name local-mgmt rule 999 state invalid 'enable'
+set firewall ipv4 name local-mgmt rule 999 log
+set firewall ipv4 name local-mgmt rule 999 state invalid
 
 # (10) From local to infra
 set firewall ipv4 name local-infra default-action 'drop'
@@ -19,30 +19,30 @@ set firewall ipv4 name local-infra description 'From local to infra'
 set firewall ipv4 name local-infra enable-default-log
 ### --- 10-infra : Accept DNS Traffic (53,953)
 set firewall ipv4 name local-infra rule 10 action 'accept'
-set firewall ipv4 name local-infra rule 10 description 'Rule: accept_dns'
+set firewall ipv4 name local-infra rule 10 description 'Rule: Accept_dns'
 set firewall ipv4 name local-infra rule 10 destination port 'domain,domain-s'
 set firewall ipv4 name local-infra rule 10 protocol 'tcp_udp'
-### --- 20-infra : Accept BGP Traffic (179)
-set firewall ipv4 name local-infra rule 20 action 'accept'
-set firewall ipv4 name local-infra rule 20 description 'Rule: accept_bgp'
-set firewall ipv4 name local-infra rule 20 destination port 'bgp'
-set firewall ipv4 name local-infra rule 20 protocol 'tcp'
-### --- 30-infra : Accept K8S API Traffic (6443)
-set firewall ipv4 name local-infra rule 30 action 'accept'
-set firewall ipv4 name local-infra rule 30 description 'Rule: accept_k8s_api'
-set firewall ipv4 name local-infra rule 30 destination port '6443'
-set firewall ipv4 name local-infra rule 30 protocol 'tcp'
-### --- 40-infra : Accept Vector Aggregator Traffic (6003)
-set firewall ipv4 name local-infra rule 40 action 'accept'
-set firewall ipv4 name local-infra rule 40 description 'Rule: accept_vector_syslog'
-set firewall ipv4 name local-infra rule 40 destination group address-group 'k8s_vector_aggregator'
-set firewall ipv4 name local-infra rule 40 destination port '6003'
-set firewall ipv4 name local-infra rule 40 protocol 'tcp'
+### --- 11-infra : Accept BGP Traffic (179)
+set firewall ipv4 name local-infra rule 11 action 'accept'
+set firewall ipv4 name local-infra rule 11 description 'Rule: Accept_bgp'
+set firewall ipv4 name local-infra rule 11 destination port 'bgp'
+set firewall ipv4 name local-infra rule 11 protocol 'tcp'
+### --- 12-infra : Accept K8S API Traffic (6443)
+set firewall ipv4 name local-infra rule 12 action 'accept'
+set firewall ipv4 name local-infra rule 12 description 'Rule: Accept_k8s_api'
+set firewall ipv4 name local-infra rule 12 destination port '6443'
+set firewall ipv4 name local-infra rule 12 protocol 'tcp'
+### --- 13-infra : Accept Vector Aggregator Traffic (6003)
+set firewall ipv4 name local-infra rule 13 action 'accept'
+set firewall ipv4 name local-infra rule 13 description 'Rule: Accept_vector_syslog'
+set firewall ipv4 name local-infra rule 13 destination group address-group 'k8s_vector_aggregator'
+set firewall ipv4 name local-infra rule 13 destination port '6003'
+set firewall ipv4 name local-infra rule 13 protocol 'tcp'
 ### --- 999-infra : Drop Invalid Packets
 set firewall ipv4 name local-infra rule 999 action 'drop'
 set firewall ipv4 name local-infra rule 999 description 'Rule: drop_invalid'
-set firewall ipv4 name local-infra rule 999 state invalid 'enable'
-set firewall ipv4 name local-infra rule 999 log 'enable'
+set firewall ipv4 name local-infra rule 999 state invalid
+set firewall ipv4 name local-infra rule 999 log
 
 # (20) From local to home
 set firewall ipv4 name local-home default-action 'drop'
@@ -51,8 +51,8 @@ set firewall ipv4 name local-home enable-default-log
 ### --- 999-home : Drop Invalid Packets
 set firewall ipv4 name local-home rule 999 action 'drop'
 set firewall ipv4 name local-home rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name local-home rule 999 log 'enable'
-set firewall ipv4 name local-home rule 999 state invalid 'enable'
+set firewall ipv4 name local-home rule 999 log
+set firewall ipv4 name local-home rule 999 state invalid
 
 # (30) From local to iot
 set firewall ipv4 name local-iot default-action 'drop'
@@ -64,15 +64,15 @@ set firewall ipv4 name local-iot rule 10 description 'Rule: Accept_MDNS'
 set firewall ipv4 name local-iot rule 10 destination port 'mdns'
 set firewall ipv4 name local-iot rule 10 protocol 'udp'
 set firewall ipv4 name local-iot rule 10 source port 'mdns'
-### --- 20-iot: Accept IGMP
-set firewall ipv4 name local-iot rule 20 action 'accept'
-set firewall ipv4 name local-iot rule 20 description 'Rule: Accept_IGMP'
-set firewall ipv4 name local-iot rule 20 protocol '2'
+### --- 11-iot: Accept IGMP
+set firewall ipv4 name local-iot rule 11 action 'accept'
+set firewall ipv4 name local-iot rule 11 description 'Rule: Accept_IGMP'
+set firewall ipv4 name local-iot rule 11 protocol '2'
 ### --- 999-iot : Drop Invalid Packets
 set firewall ipv4 name local-iot rule 999 action 'drop'
 set firewall ipv4 name local-iot rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name local-iot rule 999 log 'enable'
-set firewall ipv4 name local-iot rule 999 state invalid 'enable'
+set firewall ipv4 name local-iot rule 999 log
+set firewall ipv4 name local-iot rule 999 state invalid
 
 # (40) From local to cctv
 set firewall ipv4 name local-cctv default-action 'drop'
@@ -81,8 +81,8 @@ set firewall ipv4 name local-cctv enable-default-log
 ### --- 999-cctv : Drop Invalid Packets
 set firewall ipv4 name local-cctv rule 999 action 'drop'
 set firewall ipv4 name local-cctv rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name local-cctv rule 999 log 'enable'
-set firewall ipv4 name local-cctv rule 999 state invalid 'enable'
+set firewall ipv4 name local-cctv rule 999 log
+set firewall ipv4 name local-cctv rule 999 state invalid
 
 # (97) From local to containers
 set firewall ipv4 name local-containers default-action 'accept'
@@ -95,8 +95,8 @@ set firewall ipv4 name local-containers rule 10 protocol 'tcp_udp'
 ### --- 999-containers : Drop Invalid Packets
 set firewall ipv4 name local-containers rule 999 action 'drop'
 set firewall ipv4 name local-containers rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name local-containers rule 999 log 'enable'
-set firewall ipv4 name local-containers rule 999 state invalid 'enable'
+set firewall ipv4 name local-containers rule 999 log
+set firewall ipv4 name local-containers rule 999 state invalid
 
 # (99) From local to wan
 set firewall ipv4 name local-wan default-action 'accept'

--- a/config-parts/fw-99-wan.sh
+++ b/config-parts/fw-99-wan.sh
@@ -10,8 +10,8 @@ set firewall ipv4 name wan-mgmt enable-default-log
 ### --- 999-mgmt : Drop Invalid Packets
 set firewall ipv4 name wan-mgmt rule 999 action 'drop'
 set firewall ipv4 name wan-mgmt rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name wan-mgmt rule 999 log 'enable'
-set firewall ipv4 name wan-mgmt rule 999 state invalid 'enable'
+set firewall ipv4 name wan-mgmt rule 999 log
+set firewall ipv4 name wan-mgmt rule 999 state invalid
 
 # (10) From wan to infra
 set firewall ipv4 name wan-infra default-action 'drop'
@@ -20,8 +20,8 @@ set firewall ipv4 name wan-infra enable-default-log
 ### --- 999-infra : Drop Invalid Packets
 set firewall ipv4 name wan-infra rule 999 action 'drop'
 set firewall ipv4 name wan-infra rule 999 description 'Rule: drop_invalid'
-set firewall ipv4 name wan-infra rule 999 state invalid 'enable'
-set firewall ipv4 name wan-infra rule 999 log 'enable'
+set firewall ipv4 name wan-infra rule 999 state invalid
+set firewall ipv4 name wan-infra rule 999 log
 
 # (20) From wan to home
 set firewall ipv4 name wan-home default-action 'drop'
@@ -30,8 +30,8 @@ set firewall ipv4 name wan-home enable-default-log
 ### --- 999-home : Drop Invalid Packets
 set firewall ipv4 name wan-home rule 999 action 'drop'
 set firewall ipv4 name wan-home rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name wan-home rule 999 log 'enable'
-set firewall ipv4 name wan-home rule 999 state invalid 'enable'
+set firewall ipv4 name wan-home rule 999 log
+set firewall ipv4 name wan-home rule 999 state invalid
 
 # (30) From wan to iot
 set firewall ipv4 name wan-iot default-action 'drop'
@@ -40,8 +40,8 @@ set firewall ipv4 name wan-iot enable-default-log
 ### --- 999-iot : Drop Invalid Packets
 set firewall ipv4 name wan-iot rule 999 action 'drop'
 set firewall ipv4 name wan-iot rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name wan-iot rule 999 log 'enable'
-set firewall ipv4 name wan-iot rule 999 state invalid 'enable'
+set firewall ipv4 name wan-iot rule 999 log
+set firewall ipv4 name wan-iot rule 999 state invalid
 
 # (40) From wan to cctv
 set firewall ipv4 name wan-cctv default-action 'drop'
@@ -50,8 +50,8 @@ set firewall ipv4 name wan-cctv enable-default-log
 ### --- 999-cctv : Drop Invalid Packets
 set firewall ipv4 name wan-cctv rule 999 action 'drop'
 set firewall ipv4 name wan-cctv rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name wan-cctv rule 999 log 'enable'
-set firewall ipv4 name wan-cctv rule 999 state invalid 'enable'
+set firewall ipv4 name wan-cctv rule 999 log
+set firewall ipv4 name wan-cctv rule 999 state invalid
 
 # (97) From wan to containers
 set firewall ipv4 name wan-containers default-action 'accept'
@@ -59,8 +59,8 @@ set firewall ipv4 name wan-containers description 'From wan to containers'
 ### --- 999-containers : Drop Invalid Packets
 set firewall ipv4 name wan-containers rule 999 action 'drop'
 set firewall ipv4 name wan-containers rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name wan-containers rule 999 log 'enable'
-set firewall ipv4 name wan-containers rule 999 state invalid 'enable'
+set firewall ipv4 name wan-containers rule 999 log
+set firewall ipv4 name wan-containers rule 999 state invalid
 
 # (98) From wan to local
 set firewall ipv4 name wan-local default-action 'drop'
@@ -73,5 +73,5 @@ set firewall ipv4 name wan-local rule 10 protocol 'udp'
 ### --- 999-local : Drop Invalid Packets
 set firewall ipv4 name wan-local rule 999 action 'drop'
 set firewall ipv4 name wan-local rule 999 description 'Rule: Drop_Invalid'
-set firewall ipv4 name wan-local rule 999 log 'enable'
-set firewall ipv4 name wan-local rule 999 state invalid 'enable'
+set firewall ipv4 name wan-local rule 999 log
+set firewall ipv4 name wan-local rule 999 state invalid

--- a/config-parts/fw-group.sh
+++ b/config-parts/fw-group.sh
@@ -11,7 +11,7 @@ set firewall group interface-group IG_mgmt interface 'bond0'
 set firewall group interface-group IG_infra interface 'bond0.1611'
 set firewall group interface-group IG_home interface 'bond0.1612'
 set firewall group interface-group IG_iot interface 'bond0.1613'
-set firewall group interface-group IG_cctv interface 'bond0.1614' s
+set firewall group interface-group IG_cctv interface 'bond0.1614'
 set firewall group interface-group IG_containers interface 'pod-containers'
 
 # Router (VyOS itself)
@@ -30,6 +30,10 @@ set firewall group address-group k8s_ingress address '10.11.11.2'
 set firewall group address-group k8s_vector_aggregator address '10.11.11.11'
 set firewall group address-group k8s_mqtt address '10.11.11.12'
 
+# service group
+set firewall group address-group dns_svc address '172.16.16.2'
+set firewall group address-group dns_svc address '172.16.16.3'
+set firewall group address-group dns_svc address '172.16.16.5'
 # Vyos containers addresses
 set firewall group address-group vyos_adguard address '172.16.16.2'
 set firewall group address-group vyos_bind address '172.16.16.3'
@@ -38,6 +42,8 @@ set firewall group address-group vyos_dnsdist address '172.16.16.5'
 set firewall group address-group vyos_omada address '172.16.16.6'
 set firewall group address-group vyos_1passconnect address '172.16.16.7'
 set firewall group address-group vyos_1passsync address '172.16.16.8'
+# MAC Group
+set firewall group mac-group trusted_mac mac-address 'd0:a6:37:ea:77:2b'
 
 # Storage devices
 set firewall group address-group nas address '172.16.11.1'

--- a/config-parts/fw-ipv4.sh
+++ b/config-parts/fw-ipv4.sh
@@ -128,29 +128,29 @@ function handle_traffic {
 # Default forward policy
 set firewall ipv4 forward filter default-action 'accept'
 set firewall ipv4 forward filter rule 1 action 'accept'
-set firewall ipv4 forward filter rule 1 state established 'enable'
+set firewall ipv4 forward filter rule 1 state established
 set firewall ipv4 forward filter rule 2 action 'drop'
-set firewall ipv4 forward filter rule 2 state invalid 'enable'
+set firewall ipv4 forward filter rule 2 state invalid
 set firewall ipv4 forward filter rule 3 action 'accept'
-set firewall ipv4 forward filter rule 3 state related 'enable'
+set firewall ipv4 forward filter rule 3 state related
 
 # Default input policy
 set firewall ipv4 input filter default-action 'accept'
 set firewall ipv4 input filter rule 1 action 'accept'
-set firewall ipv4 input filter rule 1 state established 'enable'
+set firewall ipv4 input filter rule 1 state established
 set firewall ipv4 input filter rule 2 action 'drop'
-set firewall ipv4 input filter rule 2 state invalid 'enable'
+set firewall ipv4 input filter rule 2 state invalid
 set firewall ipv4 input filter rule 3 action 'accept'
-set firewall ipv4 input filter rule 3 state related 'enable'
+set firewall ipv4 input filter rule 3 state related
 
 # Default output policy
 set firewall ipv4 output filter default-action 'accept'
 set firewall ipv4 output filter rule 1 action 'accept'
-set firewall ipv4 output filter rule 1 state established 'enable'
+set firewall ipv4 output filter rule 1 state established
 set firewall ipv4 output filter rule 2 action 'drop'
-set firewall ipv4 output filter rule 2 state invalid 'enable'
+set firewall ipv4 output filter rule 2 state invalid
 set firewall ipv4 output filter rule 3 action 'accept'
-set firewall ipv4 output filter rule 3 state related 'enable'
+set firewall ipv4 output filter rule 3 state related
 
 # Ensure VyOS can talk to itself
 set firewall ipv4 output filter rule 10 action accept

--- a/config-parts/fw-ipv6.sh
+++ b/config-parts/fw-ipv6.sh
@@ -4,9 +4,9 @@
 
 set firewall ipv6 forward filter default-action 'accept'
 set firewall ipv6 forward filter rule 1 action 'accept'
-set firewall ipv6 forward filter rule 1 state established 'enable'
+set firewall ipv6 forward filter rule 1 state established
 set firewall ipv6 forward filter rule 2 action 'accept'
-set firewall ipv6 forward filter rule 2 state related 'enable'
+set firewall ipv6 forward filter rule 2 state related
 
 set firewall ipv6 forward filter rule 101 action 'accept'
 set firewall ipv6 forward filter rule 101 inbound-interface group 'IG_containers'
@@ -66,16 +66,16 @@ set firewall ipv6 forward filter rule 196 outbound-interface group 'IG_wan'
 
 set firewall ipv6 input filter default-action 'accept'
 set firewall ipv6 input filter rule 1 action 'accept'
-set firewall ipv6 input filter rule 1 state established 'enable'
+set firewall ipv6 input filter rule 1 state established
 set firewall ipv6 input filter rule 2 action 'accept'
-set firewall ipv6 input filter rule 2 state related 'enable'
+set firewall ipv6 input filter rule 2 state related
 set firewall ipv6 input filter rule 101 action 'drop'
 
 set firewall ipv6 output filter default-action 'accept'
 set firewall ipv6 output filter rule 1 action 'accept'
-set firewall ipv6 output filter rule 1 state established 'enable'
+set firewall ipv6 output filter rule 1 state established
 set firewall ipv6 output filter rule 2 action 'accept'
-set firewall ipv6 output filter rule 2 state related 'enable'
+set firewall ipv6 output filter rule 2 state related
 set firewall ipv6 output filter rule 101 action 'drop'
 
 # Ensure VyOS can talk to itself

--- a/containers/haproxy/config/haproxy.cfg
+++ b/containers/haproxy/config/haproxy.cfg
@@ -56,9 +56,9 @@ backend k8s_controlplane
     mode tcp
     option ssl-hello-chk
     balance     roundrobin
-        server k8s-m0 172.16.11.10:6443 check
-        server k8s-m1 172.16.11.11:6443 check
-        server k8s-m2 172.16.11.12:6443 check
+    server k8s-m0 172.16.11.10:6443 check
+    server k8s-m1 172.16.11.11:6443 check
+    server k8s-m2 172.16.11.12:6443 check
 
 backend talos_controlplane
     option httpchk GET /healthz
@@ -66,10 +66,10 @@ backend talos_controlplane
     mode tcp
     option ssl-hello-chk
     balance     roundrobin
-        server k8s-m0  172.16.11.10:50000 check
-        server k8s-m1  172.16.11.11:50000 check
-        server k8s-m2  172.16.11.12:50000 check
-        server k8s-w0  172.16.11.13:50000 check
-        server k8s-w1  172.16.11.14:50000 check
-        server k8s-w2  172.16.11.15:50000 check
-        server k8s-w3  172.16.11.16:50000 check
+    server k8s-m0  172.16.11.10:50000 check
+    server k8s-m1  172.16.11.11:50000 check
+    server k8s-m2  172.16.11.12:50000 check
+    server k8s-w0  172.16.11.13:50000 check
+    server k8s-w1  172.16.11.14:50000 check
+    server k8s-w2  172.16.11.15:50000 check
+    server k8s-w3  172.16.11.16:50000 check


### PR DESCRIPTION
**Firewall commands slightly change, so we need to fix.**

- `set firewall ipv4 name [rule-name] rule [rulenumber] log 'enabled' ` **To** `set firewall ipv4 name [rule-name] rule [rulenumber] log `.

- `set firewall ipv4 name [rule-name] rule [rulenumber] state invalid 'enable'` **To** `set firewall ipv4 name [rule-name] rule [rulenumber] state invalid`.

- `set firewall ipv4 forward filter rule [rulenumber] state established 'enable'` **To**  `set firewall ipv4 forward filter rule [rulenumber] state established`.

- `set firewall ipv4 forward filter rule [rulenumber] state invalid 'enable'` **To** `set firewall ipv4 forward filter rule [rulenumber] state invalid`.

- `set firewall ipv4 forward filter rule [rulenumber] state related 'enable' `**To** `set firewall ipv4 forward filter rule [rulenumber] state related`.

- `set firewall ipv4 input filter rule [rulenumber] state established 'enable'` **To**  `set firewall ipv4 input filter rule [rulenumber] state established`.

- `set firewall ipv4 input filter rule [rulenumber] state invalid 'enable'` **To** `set firewall ipv4 input filter rule [rulenumber] state invalid`.

- `set firewall ipv4 input filter rule [rulenumber] state related 'enable' `**To** `set firewall ipv4 input filter rule [rulenumber] state related`.

- `set firewall ipv4 output filter rule [rulenumber] state established 'enable'` **To**  `set firewall ipv4 output filter rule [rulenumber] state established`.

- `set firewall ipv4 output filter rule [rulenumber] state invalid 'enable'` **To** `set firewall ipv4 output filter rule [rulenumber] state invalid`.

- `set firewall ipv4 output filter rule [rulenumber] state related 'enable' `**To** `set firewall ipv4 output filter rule [rulenumber] state related`.

**_Same apply to firewall ipv6 config_**
